### PR TITLE
feat: add media player grouping (join/unjoin) support

### DIFF
--- a/custom_components/custom_universal_media_player/config_flow.py
+++ b/custom_components/custom_universal_media_player/config_flow.py
@@ -16,9 +16,11 @@ from homeassistant.components.media_player import (
 )
 from homeassistant.components.media_player.const import (
     SERVICE_CLEAR_PLAYLIST,
+    SERVICE_JOIN,
     SERVICE_PLAY_MEDIA,
     SERVICE_SELECT_SOUND_MODE,
     SERVICE_SELECT_SOURCE,
+    SERVICE_UNJOIN,
     MediaPlayerEntityFeature,
 )
 from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
@@ -96,9 +98,16 @@ COMMAND_CATEGORIES: tuple[tuple[str, tuple[str, ...]], ...] = (
     ("navigation", (SERVICE_MEDIA_NEXT_TRACK, SERVICE_MEDIA_PREVIOUS_TRACK)),
     ("volume", (SERVICE_VOLUME_UP, SERVICE_VOLUME_DOWN, SERVICE_VOLUME_SET, SERVICE_VOLUME_MUTE)),
     ("source", (SERVICE_SELECT_SOURCE, SERVICE_SELECT_SOUND_MODE)),
+    ("grouping", (SERVICE_UNJOIN,)),
 )
 
-KNOWN_COMMAND_KEYS: tuple[str, ...] = tuple(key for _category, keys in COMMAND_CATEGORIES for key in keys)
+# SERVICE_JOIN is not offered by the guided entity+action picker: it needs a
+# group_members list, which the picker cannot build (only action+target). It
+# is still a recognized command key, configurable via the custom YAML screen.
+KNOWN_COMMAND_KEYS: tuple[str, ...] = (
+    *(key for _category, keys in COMMAND_CATEGORIES for key in keys),
+    SERVICE_JOIN,
+)
 
 ACTION_REQUIRED_FEATURE: dict[str, MediaPlayerEntityFeature] = {
     SERVICE_TURN_ON: MediaPlayerEntityFeature.TURN_ON,
@@ -120,6 +129,8 @@ ACTION_REQUIRED_FEATURE: dict[str, MediaPlayerEntityFeature] = {
     SERVICE_VOLUME_MUTE: MediaPlayerEntityFeature.VOLUME_MUTE,
     SERVICE_SELECT_SOURCE: MediaPlayerEntityFeature.SELECT_SOURCE,
     SERVICE_SELECT_SOUND_MODE: MediaPlayerEntityFeature.SELECT_SOUND_MODE,
+    SERVICE_JOIN: MediaPlayerEntityFeature.GROUPING,
+    SERVICE_UNJOIN: MediaPlayerEntityFeature.GROUPING,
 }
 
 DEVICE_CLASS_LABELS: dict[str, str] = {
@@ -137,7 +148,9 @@ DEVICE_CLASS_OPTIONS: tuple[str, ...] = tuple(
     ),
 )
 
-ACTION_OPTIONS: tuple[str, ...] = tuple(sorted(f"{MEDIA_PLAYER_DOMAIN}.{key}" for key in KNOWN_COMMAND_KEYS))
+ACTION_OPTIONS: tuple[str, ...] = tuple(
+    sorted(f"{MEDIA_PLAYER_DOMAIN}.{key}" for key in KNOWN_COMMAND_KEYS if key != SERVICE_JOIN)
+)
 
 
 def _entity_field(key: str, *, error: bool = False) -> str:

--- a/custom_components/custom_universal_media_player/config_flow.py
+++ b/custom_components/custom_universal_media_player/config_flow.py
@@ -98,16 +98,10 @@ COMMAND_CATEGORIES: tuple[tuple[str, tuple[str, ...]], ...] = (
     ("navigation", (SERVICE_MEDIA_NEXT_TRACK, SERVICE_MEDIA_PREVIOUS_TRACK)),
     ("volume", (SERVICE_VOLUME_UP, SERVICE_VOLUME_DOWN, SERVICE_VOLUME_SET, SERVICE_VOLUME_MUTE)),
     ("source", (SERVICE_SELECT_SOURCE, SERVICE_SELECT_SOUND_MODE)),
-    ("grouping", (SERVICE_UNJOIN,)),
+    ("grouping", (SERVICE_JOIN, SERVICE_UNJOIN)),
 )
 
-# SERVICE_JOIN is not offered by the guided entity+action picker: it needs a
-# group_members list, which the picker cannot build (only action+target). It
-# is still a recognized command key, configurable via the custom YAML screen.
-KNOWN_COMMAND_KEYS: tuple[str, ...] = (
-    *(key for _category, keys in COMMAND_CATEGORIES for key in keys),
-    SERVICE_JOIN,
-)
+KNOWN_COMMAND_KEYS: tuple[str, ...] = tuple(key for _category, keys in COMMAND_CATEGORIES for key in keys)
 
 ACTION_REQUIRED_FEATURE: dict[str, MediaPlayerEntityFeature] = {
     SERVICE_TURN_ON: MediaPlayerEntityFeature.TURN_ON,
@@ -148,9 +142,7 @@ DEVICE_CLASS_OPTIONS: tuple[str, ...] = tuple(
     ),
 )
 
-ACTION_OPTIONS: tuple[str, ...] = tuple(
-    sorted(f"{MEDIA_PLAYER_DOMAIN}.{key}" for key in KNOWN_COMMAND_KEYS if key != SERVICE_JOIN)
-)
+ACTION_OPTIONS: tuple[str, ...] = tuple(sorted(f"{MEDIA_PLAYER_DOMAIN}.{key}" for key in KNOWN_COMMAND_KEYS))
 
 
 def _entity_field(key: str, *, error: bool = False) -> str:

--- a/custom_components/custom_universal_media_player/config_flow.py
+++ b/custom_components/custom_universal_media_player/config_flow.py
@@ -899,10 +899,11 @@ class CustomUniversalMediaPlayerConfigFlow(ConfigFlow, domain=DOMAIN):
                 return await self.async_step_config_menu()
 
         description_placeholders = {"problems": _format_problems(problems)}
+        schema, preview_yaml = self._commands_review_schema(user_input if errors else None)
 
         return self.async_show_form(
             step_id="config_commands_custom",
-            data_schema=self._commands_review_schema(user_input if errors else None),
+            data_schema=self.add_suggested_values_to_schema(schema, {CONF_COMMANDS: preview_yaml}),
             errors=errors,
             description_placeholders=description_placeholders,
         )
@@ -969,8 +970,12 @@ class CustomUniversalMediaPlayerConfigFlow(ConfigFlow, domain=DOMAIN):
 
         return unknown
 
-    def _commands_review_schema(self, user_input: dict[str, Any] | None = None) -> vol.Schema:
+    def _commands_review_schema(self, user_input: dict[str, Any] | None = None) -> tuple[vol.Schema, str]:
         """Build the review step schema, a single YAML textarea for all commands.
+
+        The field has no schema default: it's pre-filled via a suggested_value
+        instead, so clearing the textarea and submitting it empty is respected
+        instead of the frontend silently reverting to the previous value.
 
         Args:
             user_input: The previously submitted (invalid) form data, if any,
@@ -978,7 +983,8 @@ class CustomUniversalMediaPlayerConfigFlow(ConfigFlow, domain=DOMAIN):
                 instead of reverting to the previously saved commands.
 
         Returns:
-            The voluptuous schema for the review form.
+            A tuple of the voluptuous schema for the review form, and the
+            suggested value to overlay on it.
 
         """
         if user_input is not None:
@@ -989,9 +995,8 @@ class CustomUniversalMediaPlayerConfigFlow(ConfigFlow, domain=DOMAIN):
                 yaml.safe_dump(json.loads(json.dumps(existing_commands)), sort_keys=False) if existing_commands else ""
             )
 
-        return vol.Schema(
-            {vol.Optional(CONF_COMMANDS, default=preview_yaml): TextSelector(TextSelectorConfig(multiline=True))},
-        )
+        schema = vol.Schema({vol.Optional(CONF_COMMANDS): TextSelector(TextSelectorConfig(multiline=True))})
+        return schema, preview_yaml
 
     async def async_step_config_attributes_custom(self, user_input: dict[str, Any] | None = None) -> ConfigFlowResult:
         """Handle the raw YAML attribute overrides step.
@@ -1045,13 +1050,11 @@ class CustomUniversalMediaPlayerConfigFlow(ConfigFlow, domain=DOMAIN):
 
         description_placeholders = {"problems": _format_problems(problems)}
 
-        schema = vol.Schema(
-            {vol.Optional(CONF_ATTRS, default=preview_yaml): TextSelector(TextSelectorConfig(multiline=True))},
-        )
+        schema = vol.Schema({vol.Optional(CONF_ATTRS): TextSelector(TextSelectorConfig(multiline=True))})
 
         return self.async_show_form(
             step_id="config_attributes_custom",
-            data_schema=schema,
+            data_schema=self.add_suggested_values_to_schema(schema, {CONF_ATTRS: preview_yaml}),
             errors=errors,
             description_placeholders=description_placeholders,
         )

--- a/custom_components/custom_universal_media_player/media_player.py
+++ b/custom_components/custom_universal_media_player/media_player.py
@@ -1071,6 +1071,35 @@ class CustomUniversalMediaPlayer(MediaPlayerEntity):  # pylint: disable=too-many
 
         return state.attributes.get(ATTR_ACTIVE_CHILD, entity_id)
 
+    @property
+    @override
+    def group_members(self) -> list[str] | None:  # pyright: ignore[reportIncompatibleVariableOverride]
+        """List of members which are currently grouped together.
+
+        The active child's own group_members are real entity IDs (e.g. a
+        Sonos speaker). Each is mapped back to the custom_universal_media_player
+        entity that currently has it as its active child, if any, so the
+        join dialog and the group count badge reflect the virtual entities
+        the user actually configured - falling back to the real entity ID
+        when no matching virtual entity is found.
+
+        Returns:
+            The list of group member entity IDs, or None if the active
+            child doesn't report any.
+
+        """
+        real_members = self._child_attr(ATTR_GROUP_MEMBERS)
+        if not real_members:
+            return real_members
+
+        real_to_virtual = {
+            state.attributes[ATTR_ACTIVE_CHILD]: state.entity_id
+            for state in self.hass.states.async_all(MEDIA_PLAYER_DOMAIN)
+            if ATTR_ACTIVE_CHILD in state.attributes
+        }
+
+        return [real_to_virtual.get(entity_id, entity_id) for entity_id in real_members]
+
     @override
     async def async_unjoin_player(self) -> None:
         """Remove the active child from its current group."""

--- a/custom_components/custom_universal_media_player/media_player.py
+++ b/custom_components/custom_universal_media_player/media_player.py
@@ -898,6 +898,9 @@ class CustomUniversalMediaPlayer(MediaPlayerEntity):  # pylint: disable=too-many
         """
         state_attr: dict[str, Any] = {}
 
+        if self.support_grouping:
+            state_attr[ATTR_GROUP_MEMBERS] = self.group_members
+
         if self.state == MediaPlayerState.OFF:
             return state_attr
 

--- a/custom_components/custom_universal_media_player/media_player.py
+++ b/custom_components/custom_universal_media_player/media_player.py
@@ -402,7 +402,13 @@ class CustomUniversalMediaPlayer(MediaPlayerEntity):  # pylint: disable=too-many
 
         If allow_override is True and a command override is defined for the
         given service, the override is called instead of delegating to the
-        active child.
+        active child. The call's own data (e.g. media_content_id for
+        play_media, volume_level for volume_set) is merged into the
+        override's data so it reaches the target service even if the
+        override doesn't reference it via a Jinja2 template - an explicit
+        key in the override's own data still takes priority. Likewise, if
+        the override doesn't define its own target, it defaults to the
+        active child, same as a non-overridden command would.
 
         Args:
             service_name: The name of the media player service to call.
@@ -415,9 +421,15 @@ class CustomUniversalMediaPlayer(MediaPlayerEntity):  # pylint: disable=too-many
             service_data = {}
 
         if allow_override and service_name in self._cmds:
+            override = dict(self._cmds[service_name])
+            override["data"] = {**service_data, **override.get("data", {})}
+
+            if "target" not in override and (active_child := self._child_state) is not None:
+                override["target"] = {ATTR_ENTITY_ID: active_child.entity_id}
+
             await async_call_from_config(
                 self.hass,
-                self._cmds[service_name],
+                override,
                 variables=service_data,
                 blocking=True,
                 validate_config=False,
@@ -781,7 +793,7 @@ class CustomUniversalMediaPlayer(MediaPlayerEntity):  # pylint: disable=too-many
 
         """
         flags: MediaPlayerEntityFeature = self._child_attr(ATTR_SUPPORTED_FEATURES) or MediaPlayerEntityFeature(0)
-        flags &= ~MediaPlayerEntityFeature.GROUPING
+        flags &= ~(MediaPlayerEntityFeature.GROUPING | MediaPlayerEntityFeature.BROWSE_MEDIA)
 
         if SERVICE_JOIN in self._cmds:
             flags |= MediaPlayerEntityFeature.GROUPING

--- a/custom_components/custom_universal_media_player/media_player.py
+++ b/custom_components/custom_universal_media_player/media_player.py
@@ -1038,12 +1038,38 @@ class CustomUniversalMediaPlayer(MediaPlayerEntity):  # pylint: disable=too-many
     async def async_join_players(self, group_members: list[str]) -> None:
         """Join the active child with other players.
 
+        group_members may reference other custom_universal_media_player
+        entities rather than real ones (they're what the join dialog lists
+        for this player). The underlying platform (Sonos, Cast, etc.) only
+        knows its own real entities, so each virtual member is resolved to
+        its own active child before the service call.
+
         Args:
             group_members: The entity IDs of the players to join.
 
         """
-        data = {ATTR_GROUP_MEMBERS: group_members}
+        resolved_members = [self._resolve_real_entity_id(entity_id) for entity_id in group_members]
+        data = {ATTR_GROUP_MEMBERS: resolved_members}
         await self._async_call_service(SERVICE_JOIN, data, allow_override=True)
+
+    def _resolve_real_entity_id(self, entity_id: str) -> str:
+        """Resolve a group member to a real (non-virtual) entity ID.
+
+        Args:
+            entity_id: The entity ID to resolve, possibly another
+                custom_universal_media_player entity.
+
+        Returns:
+            The entity's own active_child entity ID if it is another
+            custom_universal_media_player instance, otherwise the entity ID
+            unchanged.
+
+        """
+        state = self.hass.states.get(entity_id)
+        if state is None:
+            return entity_id
+
+        return state.attributes.get(ATTR_ACTIVE_CHILD, entity_id)
 
     @override
     async def async_unjoin_player(self) -> None:

--- a/custom_components/custom_universal_media_player/media_player.py
+++ b/custom_components/custom_universal_media_player/media_player.py
@@ -15,6 +15,7 @@ from homeassistant.components.media_player import (
 from homeassistant.components.media_player.const import (
     ATTR_APP_ID,
     ATTR_APP_NAME,
+    ATTR_GROUP_MEMBERS,
     ATTR_INPUT_SOURCE,
     ATTR_INPUT_SOURCE_LIST,
     ATTR_MEDIA_ALBUM_ARTIST,
@@ -41,9 +42,11 @@ from homeassistant.components.media_player.const import (
     ATTR_SOUND_MODE_LIST,
     DOMAIN as MEDIA_PLAYER_DOMAIN,
     SERVICE_CLEAR_PLAYLIST,
+    SERVICE_JOIN,
     SERVICE_PLAY_MEDIA,
     SERVICE_SELECT_SOUND_MODE,
     SERVICE_SELECT_SOURCE,
+    SERVICE_UNJOIN,
     MediaPlayerEntityFeature,
     MediaPlayerState,
     MediaType,
@@ -778,6 +781,10 @@ class CustomUniversalMediaPlayer(MediaPlayerEntity):  # pylint: disable=too-many
 
         """
         flags: MediaPlayerEntityFeature = self._child_attr(ATTR_SUPPORTED_FEATURES) or MediaPlayerEntityFeature(0)
+        flags &= ~MediaPlayerEntityFeature.GROUPING
+
+        if SERVICE_JOIN in self._cmds:
+            flags |= MediaPlayerEntityFeature.GROUPING
 
         if SERVICE_TURN_ON in self._cmds:
             flags |= MediaPlayerEntityFeature.TURN_ON
@@ -1014,6 +1021,22 @@ class CustomUniversalMediaPlayer(MediaPlayerEntity):  # pylint: disable=too-many
     async def async_clear_playlist(self) -> None:
         """Clear player playlist."""
         await self._async_call_service(SERVICE_CLEAR_PLAYLIST, allow_override=True)
+
+    @override
+    async def async_join_players(self, group_members: list[str]) -> None:
+        """Join the active child with other players.
+
+        Args:
+            group_members: The entity IDs of the players to join.
+
+        """
+        data = {ATTR_GROUP_MEMBERS: group_members}
+        await self._async_call_service(SERVICE_JOIN, data, allow_override=True)
+
+    @override
+    async def async_unjoin_player(self) -> None:
+        """Remove the active child from its current group."""
+        await self._async_call_service(SERVICE_UNJOIN, allow_override=True)
 
     @override
     async def async_set_shuffle(self, shuffle: bool) -> None:

--- a/custom_components/custom_universal_media_player/strings.json
+++ b/custom_components/custom_universal_media_player/strings.json
@@ -108,6 +108,14 @@
               "select_sound_mode__entity_error": "⚠️ SELECT SOUND MODE",
               "select_sound_mode__action": "Select an action"
             }
+          },
+          "category_grouping": {
+            "name": "Grouping",
+            "data": {
+              "unjoin__entity": "UNJOIN",
+              "unjoin__entity_error": "⚠️ UNJOIN",
+              "unjoin__action": "Select an action"
+            }
           }
         }
       },

--- a/custom_components/custom_universal_media_player/strings.json
+++ b/custom_components/custom_universal_media_player/strings.json
@@ -112,6 +112,9 @@
           "category_grouping": {
             "name": "Grouping",
             "data": {
+              "join__entity": "JOIN",
+              "join__entity_error": "⚠️ JOIN",
+              "join__action": "Select an action",
               "unjoin__entity": "UNJOIN",
               "unjoin__entity_error": "⚠️ UNJOIN",
               "unjoin__action": "Select an action"

--- a/custom_components/custom_universal_media_player/translations/en.json
+++ b/custom_components/custom_universal_media_player/translations/en.json
@@ -108,6 +108,14 @@
               "select_sound_mode__entity_error": "⚠️ SELECT SOUND MODE",
               "select_sound_mode__action": "Select an action"
             }
+          },
+          "category_grouping": {
+            "name": "Grouping",
+            "data": {
+              "unjoin__entity": "UNJOIN",
+              "unjoin__entity_error": "⚠️ UNJOIN",
+              "unjoin__action": "Select an action"
+            }
           }
         }
       },

--- a/custom_components/custom_universal_media_player/translations/en.json
+++ b/custom_components/custom_universal_media_player/translations/en.json
@@ -112,6 +112,9 @@
           "category_grouping": {
             "name": "Grouping",
             "data": {
+              "join__entity": "JOIN",
+              "join__entity_error": "⚠️ JOIN",
+              "join__action": "Select an action",
               "unjoin__entity": "UNJOIN",
               "unjoin__entity_error": "⚠️ UNJOIN",
               "unjoin__action": "Select an action"

--- a/scripts/check_config_flow
+++ b/scripts/check_config_flow
@@ -172,6 +172,51 @@ def check_yaml_screens_preserve_input_on_error() -> None:
     asyncio.run(_check_attributes())
 
 
+def check_yaml_screens_have_no_static_default() -> None:
+    """Regression test: YAML textarea fields must not use a static default.
+
+    A vol.Optional(key, default=...) field is silently re-filled by the
+    frontend even after the user clears the textarea and submits it empty,
+    because "empty" is treated as "revert to default" rather than as a real
+    empty value. The preview must be passed as a suggested_value instead
+    (via add_suggested_values_to_schema), which is a pure UI hint and is
+    never re-injected - only that way does submitting an empty textarea
+    actually clear the stored commands/attributes.
+    """
+    import voluptuous as vol  # noqa: PLC0415
+
+    import custom_universal_media_player.config_flow as cf  # noqa: PLC0415
+    from custom_universal_media_player.const import CONF_ATTRS, CONF_COMMANDS  # noqa: PLC0415
+
+    async def _check_commands_review_clears() -> None:
+        flow = _make_flow(cf, {CONF_COMMANDS: {"turn_on": {"action": "media_player.turn_on"}}})
+        field = next(iter(flow._commands_review_schema()[0].schema))  # noqa: SLF001
+        no_static_default = field.default is vol.UNDEFINED
+
+        await flow.async_step_config_commands_custom({CONF_COMMANDS: ""})
+        report(
+            "config_commands_custom: no static default, and empty submission clears commands",
+            no_static_default and flow._data.get(CONF_COMMANDS) == {},  # noqa: SLF001
+            f"no_static_default={no_static_default}, commands={flow._data.get(CONF_COMMANDS)!r}",  # noqa: SLF001
+        )
+
+    async def _check_attributes_clears() -> None:
+        flow = _make_flow(cf, {CONF_ATTRS: {"state": "media_player.bedroom"}}, known_entities={"media_player.bedroom"})
+        result = await flow.async_step_config_attributes_custom()
+        field = next(iter(result["data_schema"].schema))
+        no_static_default = field.default is vol.UNDEFINED
+
+        await flow.async_step_config_attributes_custom({CONF_ATTRS: ""})
+        report(
+            "config_attributes_custom: no static default, and empty submission clears attributes",
+            no_static_default and flow._data.get(CONF_ATTRS) == {},  # noqa: SLF001
+            f"no_static_default={no_static_default}, attrs={flow._data.get(CONF_ATTRS)!r}",  # noqa: SLF001
+        )
+
+    asyncio.run(_check_commands_review_clears())
+    asyncio.run(_check_attributes_clears())
+
+
 def check_actions_no_stale_suggestion() -> None:
     """Regression test: clearing a command must not resurrect it on revisit.
 
@@ -375,6 +420,7 @@ def main() -> int:
     check_json_files()
     check_imports()
     check_yaml_screens_preserve_input_on_error()
+    check_yaml_screens_have_no_static_default()
     check_actions_no_stale_suggestion()
     check_empty_entity_id_does_not_crash()
     check_command_validation_is_cumulative()

--- a/scripts/check_config_flow
+++ b/scripts/check_config_flow
@@ -149,11 +149,11 @@ def check_yaml_screens_preserve_input_on_error() -> None:
         bad_yaml = "turn_on:\n  action: media_player.turn_on\n  target:\n    entity_id: media_player.does_not_exist\n"
         result = await flow.async_step_config_commands_custom({CONF_COMMANDS: bad_yaml})
         schema = result["data_schema"]
-        field_default = next(iter(schema.schema)).default()
+        suggested = next(iter(schema.schema)).description["suggested_value"]
         report(
             "config_commands_custom: preserves submitted YAML on error",
-            field_default == bad_yaml,
-            f"expected {bad_yaml!r}, got {field_default!r}",
+            suggested == bad_yaml,
+            f"expected {bad_yaml!r}, got {suggested!r}",
         )
 
     async def _check_attributes() -> None:
@@ -161,11 +161,11 @@ def check_yaml_screens_preserve_input_on_error() -> None:
         bad_yaml = "state: [unbalanced\n"
         result = await flow.async_step_config_attributes_custom({CONF_ATTRS: bad_yaml})
         schema = result["data_schema"]
-        field_default = next(iter(schema.schema)).default()
+        suggested = next(iter(schema.schema)).description["suggested_value"]
         report(
             "config_attributes_custom: preserves submitted YAML on error",
-            field_default == bad_yaml,
-            f"expected {bad_yaml!r}, got {field_default!r}",
+            suggested == bad_yaml,
+            f"expected {bad_yaml!r}, got {suggested!r}",
         )
 
     asyncio.run(_check_commands_review())


### PR DESCRIPTION
- Add join/unjoin commands, so players can be grouped/ungrouped from the UI
- Fix the join dialog: it now correctly shows which players are already grouped, and the group count badge works
- Fix the "browse media" and "group" buttons flickering on/off depending on which child was currently active
- Fix commands with dynamic data (e.g. play_media, volume_set) failing when overridden with a simple custom action
- Fix custom commands/attributes YAML fields that couldn't be cleared once filled in