### PR TITLE
fix: restore templated commands and stop double-proxying media images

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,66 @@ media_player:
       volume_level: media_player.google_home_bureau|volume_level
 ```
 
+## Passing values to commands
+
+Some commands carry a value: `volume_set` gets a volume, `select_source` gets a source name, `play_media` gets a media id. How that value reaches your command depends on what the command targets.
+
+### Targeting the same `media_player` action
+
+When a command calls `media_player.<the same command>`, the value is forwarded for you. This is what the guided configuration writes, and why the commands in the example above need no `data`:
+
+```yaml
+volume_set:
+  action: media_player.volume_set
+  target:
+    entity_id: media_player.google_home_bureau
+```
+
+### Targeting anything else
+
+When a command calls another action (`number.set_value`, `input_select.select_option`, `script.*`, ...), that action has its own fields and would reject the media player's ones. Read the value from a Jinja2 variable instead, and put it in the field the action actually expects:
+
+```yaml
+volume_set:
+  action: number.set_value
+  target:
+    entity_id: number.rx_v685_volume
+  data:
+    value: "{{ volume_level }}"       # not volume_level: ...
+select_source:
+  action: input_select.select_option
+  target:
+    entity_id: input_select.media_activity
+  data:
+    option: "{{ source }}"            # not source: ...
+```
+
+The variables available are the ones the command itself carries:
+
+| Command | Variables |
+| --- | --- |
+| `volume_set` | `volume_level` (float, `0`-`1`) |
+| `volume_mute` | `is_volume_muted` (boolean) |
+| `select_source` | `source` |
+| `select_sound_mode` | `sound_mode` |
+| `play_media` | `media_content_type`, `media_content_id` |
+| `shuffle_set` | `shuffle` (boolean) |
+| `repeat_set` | `repeat` (`off`, `all`, `one`) |
+| `join` | `group_members` (list of entity IDs) |
+
+Every other command (`turn_on`, `media_play`, `volume_up`, `unjoin`, ...) carries no value, so its `data` only needs whatever the target action requires. Templates are free to read the rest of Home Assistant too, which is how a stepped volume is built without any variable:
+
+```yaml
+volume_up:
+  action: number.set_value
+  target:
+    entity_id: number.rx_v685_volume
+  data:
+    value: "{{ states('number.rx_v685_volume') | float(0) + 0.01 }}"
+```
+
+Note that `volume_level` is expected in the `0`-`1` range on both sides. If the entity behind it uses another scale (a receiver's dB value, a `0`-`100` percentage), convert it in the template, and convert it back in the matching `attributes` entry.
+
 ## Contributing
 
 Found a bug or have a feature request? Please open an [issue](https://github.com/bastgau/ha-custom-universal-media-player/issues) on GitHub.

--- a/custom_components/custom_universal_media_player/config_flow.py
+++ b/custom_components/custom_universal_media_player/config_flow.py
@@ -722,7 +722,7 @@ class CustomUniversalMediaPlayerConfigFlow(ConfigFlow, domain=DOMAIN):
         self._data.setdefault(CONF_COMMANDS, {})
         return self._finalize()
 
-    async def async_step_config_commands(self, user_input: dict[str, Any] | None = None) -> ConfigFlowResult:
+    async def async_step_config_commands(self, user_input: dict[str, Any] | None = None) -> ConfigFlowResult:  # pylint: disable=too-many-locals
         """Handle the entity/action picker step.
 
         Submitting this screen replaces all commands with what is picked
@@ -778,7 +778,7 @@ class CustomUniversalMediaPlayerConfigFlow(ConfigFlow, domain=DOMAIN):
             errors=errors,
         )
 
-    def _commands_schema(
+    def _commands_schema(  # pylint: disable=too-many-locals
         self,
         user_input: dict[str, Any] | None = None,
         incomplete_keys: set[str] | None = None,

--- a/custom_components/custom_universal_media_player/config_flow.py
+++ b/custom_components/custom_universal_media_player/config_flow.py
@@ -61,6 +61,7 @@ from homeassistant.helpers.selector import (
     TextSelector,
     TextSelectorConfig,
 )
+from homeassistant.helpers.template import Template
 from homeassistant.util import slugify
 from homeassistant.util.uuid import random_uuid_hex
 
@@ -221,6 +222,34 @@ def _format_problems(problems: list[str]) -> str:
 
     bullet_list = "\n".join(f"- {problem}" for problem in problems)
     return f"\n\nInvalid configuration:\n{bullet_list}"
+
+
+def _detemplatize(value: Any) -> Any:
+    """Turn the Template objects in a validated command back into raw strings.
+
+    cv.SERVICE_SCHEMA compiles every "{{ ... }}" string into a Template, and a
+    Template cannot be serialized to JSON. Left as-is in a config entry it
+    makes the whole .storage/core.config_entries write fail, so nothing is
+    ever persisted. Commands are stored as raw strings instead and validated
+    again when they are called.
+
+    Args:
+        value: A validated command, or any part of one.
+
+    Returns:
+        The same structure with every Template replaced by its source string.
+
+    """
+    if isinstance(value, Template):
+        return value.template
+
+    if isinstance(value, dict):
+        return {key: _detemplatize(item) for key, item in value.items()}
+
+    if isinstance(value, list):
+        return [_detemplatize(item) for item in value]
+
+    return value
 
 
 def _is_simple_command(command: dict[str, Any] | None) -> bool:
@@ -893,7 +922,7 @@ class CustomUniversalMediaPlayerConfigFlow(ConfigFlow, domain=DOMAIN):
                     if problems:
                         errors["base"] = "invalid_commands"
                     else:
-                        self._data[CONF_COMMANDS] = validated
+                        self._data[CONF_COMMANDS] = _detemplatize(validated)
 
             if not errors:
                 return await self.async_step_config_menu()
@@ -1178,7 +1207,7 @@ class CustomUniversalMediaPlayerConfigFlow(ConfigFlow, domain=DOMAIN):
         data: dict[str, Any] = {
             CONF_NAME: import_data[CONF_NAME],
             CONF_CHILDREN: import_data.get(CONF_CHILDREN, []),
-            CONF_COMMANDS: import_data.get(CONF_COMMANDS, {}),
+            CONF_COMMANDS: _detemplatize(import_data.get(CONF_COMMANDS, {})),
             CONF_ATTRS: import_data.get(CONF_ATTRS, {}),
             CONF_BROWSE_MEDIA_ENTITY: import_data.get(CONF_BROWSE_MEDIA_ENTITY),
             CONF_UNIQUE_ID: unique_id,

--- a/custom_components/custom_universal_media_player/media_player.py
+++ b/custom_components/custom_universal_media_player/media_player.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from copy import copy
 from typing import TYPE_CHECKING, Any, override
+from urllib.parse import urlparse
 
 import voluptuous as vol
 
@@ -925,9 +926,15 @@ class CustomUniversalMediaPlayer(MediaPlayerEntity):  # pylint: disable=too-many
             if (value := getattr(self, attr)) is not None:
                 state_attr[attr] = value
 
-        # Use local image proxy if the URL is not HTTPS, as HA runs over HTTPS
-        if ATTR_ENTITY_PICTURE_LOCAL not in state_attr or "https:" not in state_attr[ATTR_ENTITY_PICTURE_LOCAL]:
-            state_attr[ATTR_ENTITY_PICTURE_LOCAL] = self.media_image_local
+        # The frontend prefers entity_picture_local over entity_picture, so it
+        # is only worth publishing for a remote picture served over plain HTTP,
+        # which a browser would refuse to load into an HTTPS page. The picture
+        # usually is the active child's own proxy URL, and proxying that one
+        # again would only make Home Assistant fetch itself.
+        if (image_url := self.media_image_url) is not None:
+            parsed = urlparse(image_url)
+            if parsed.hostname is not None and parsed.scheme != "https":
+                state_attr[ATTR_ENTITY_PICTURE_LOCAL] = self.media_image_local
 
         return state_attr
 

--- a/custom_components/custom_universal_media_player/media_player.py
+++ b/custom_components/custom_universal_media_player/media_player.py
@@ -181,7 +181,7 @@ PLATFORM_SCHEMA = MEDIA_PLAYER_PLATFORM_SCHEMA.extend(  # pyright: ignore[report
 async def async_setup_platform(
     hass: HomeAssistant,
     config: ConfigType,
-    async_add_entities: AddEntitiesCallback,  # noqa: ARG001
+    async_add_entities: AddEntitiesCallback,  # noqa: ARG001 # pylint: disable=unused-argument
     discovery_info: DiscoveryInfoType | None = None,  # pylint: disable=unused-argument  # noqa: ARG001
 ) -> None:
     """Import the YAML platform configuration into a config entry.
@@ -429,17 +429,17 @@ class CustomUniversalMediaPlayer(MediaPlayerEntity):  # pylint: disable=too-many
             service_data = {}
 
         if allow_override and service_name in self._cmds:
-            override = dict(self._cmds[service_name])
+            cmd_override = dict(self._cmds[service_name])
 
             # A templated action isn't known until render time, so it never
             # qualifies as a pass-through. CONF_SERVICE is the legacy spelling
             # of CONF_ACTION and may still be around in an older command.
-            action = override.get(CONF_ACTION) or override.get(CONF_SERVICE)
+            action = cmd_override.get(CONF_ACTION) or cmd_override.get(CONF_SERVICE)
             if isinstance(action, str) and action == f"{MEDIA_PLAYER_DOMAIN}.{service_name}":
-                override["data"] = {**service_data, **override.get("data", {})}
+                cmd_override["data"] = {**service_data, **cmd_override.get("data", {})}
 
-            if "target" not in override and (active_child := self._child_state) is not None:
-                override["target"] = {ATTR_ENTITY_ID: active_child.entity_id}
+            if "target" not in cmd_override and (active_child := self._child_state) is not None:
+                cmd_override["target"] = {ATTR_ENTITY_ID: active_child.entity_id}
 
             # Commands are stored as raw strings in the config entry, so they
             # have to be validated here to turn "{{ ... }}" back into a
@@ -447,7 +447,7 @@ class CustomUniversalMediaPlayer(MediaPlayerEntity):  # pylint: disable=too-many
             # the command's Jinja2 would reach the target service verbatim.
             await async_call_from_config(
                 self.hass,
-                override,
+                cmd_override,
                 variables=service_data,
                 blocking=True,
                 validate_config=True,

--- a/custom_components/custom_universal_media_player/media_player.py
+++ b/custom_components/custom_universal_media_player/media_player.py
@@ -58,8 +58,10 @@ from homeassistant.const import (
     ATTR_ENTITY_ID,
     ATTR_ENTITY_PICTURE,
     ATTR_SUPPORTED_FEATURES,
+    CONF_ACTION,
     CONF_DEVICE_CLASS,
     CONF_NAME,
+    CONF_SERVICE,
     CONF_STATE,
     CONF_STATE_TEMPLATE,
     CONF_UNIQUE_ID,
@@ -404,11 +406,16 @@ class CustomUniversalMediaPlayer(MediaPlayerEntity):  # pylint: disable=too-many
         given service, the override is called instead of delegating to the
         active child. The call's own data (e.g. media_content_id for
         play_media, volume_level for volume_set) is merged into the
-        override's data so it reaches the target service even if the
-        override doesn't reference it via a Jinja2 template - an explicit
-        key in the override's own data still takes priority. Likewise, if
-        the override doesn't define its own target, it defaults to the
-        active child, same as a non-overridden command would.
+        override's data only when the override is a pass-through to the same
+        media_player service, since that is the only case where the target
+        accepts the same keys - the commands built by the guided config flow
+        rely on it, as they carry no data of their own. Any other target
+        (a number, an input_select, a script, ...) would reject those keys as
+        extra, so it only receives what the override itself defines; the
+        call's data stays reachable there through the Jinja2 variables. An
+        explicit key in the override's own data always takes priority.
+        Likewise, if the override doesn't define its own target, it defaults
+        to the active child, same as a non-overridden command would.
 
         Args:
             service_name: The name of the media player service to call.
@@ -422,7 +429,13 @@ class CustomUniversalMediaPlayer(MediaPlayerEntity):  # pylint: disable=too-many
 
         if allow_override and service_name in self._cmds:
             override = dict(self._cmds[service_name])
-            override["data"] = {**service_data, **override.get("data", {})}
+
+            # A templated action isn't known until render time, so it never
+            # qualifies as a pass-through. CONF_SERVICE is the legacy spelling
+            # of CONF_ACTION and may still be around in an older command.
+            action = override.get(CONF_ACTION) or override.get(CONF_SERVICE)
+            if isinstance(action, str) and action == f"{MEDIA_PLAYER_DOMAIN}.{service_name}":
+                override["data"] = {**service_data, **override.get("data", {})}
 
             if "target" not in override and (active_child := self._child_state) is not None:
                 override["target"] = {ATTR_ENTITY_ID: active_child.entity_id}

--- a/custom_components/custom_universal_media_player/media_player.py
+++ b/custom_components/custom_universal_media_player/media_player.py
@@ -440,12 +440,16 @@ class CustomUniversalMediaPlayer(MediaPlayerEntity):  # pylint: disable=too-many
             if "target" not in override and (active_child := self._child_state) is not None:
                 override["target"] = {ATTR_ENTITY_ID: active_child.entity_id}
 
+            # Commands are stored as raw strings in the config entry, so they
+            # have to be validated here to turn "{{ ... }}" back into a
+            # Template - render_complex() leaves plain strings untouched and
+            # the command's Jinja2 would reach the target service verbatim.
             await async_call_from_config(
                 self.hass,
                 override,
                 variables=service_data,
                 blocking=True,
-                validate_config=False,
+                validate_config=True,
             )
             return
 


### PR DESCRIPTION
### Fixed

- Command overrides targeting another domain (`number.set_value`, `input_select.select_option`, ...) no longer receive the media player's own data as extra keys, which made `volume_set` and `select_source` fail
- Command templates are now rendered again: `{{ source }}`, `{{ volume_level }}` and `{{ states(...) }}` reach the target action as values instead of raw text
- Commands are stored as raw template strings, so a config entry using them is persisted instead of silently failing to save and vanishing on restart
- The entity picture is no longer proxied a second time when it already points at the active child's proxy URL, which showed a broken image on the card and in the more-info dialog

### Docs

- Document how a command receives the value it carries, and the variable each one exposes