### PR TITLE
fix: repair the YAML import and stop rejecting or crashing on valid templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,10 @@ The integration is configured through the Home Assistant UI (config flow), no YA
 
 Existing YAML-based setups (`media_player: - platform: custom_universal_media_player`) are still imported automatically into a config entry, with a repair issue flagged to migrate away from YAML. Please check the notice of the [universal media player](https://www.home-assistant.io/integrations/universal/#usage-examples) for the underlying attribute/command semantics.
 
+For as long as the YAML block is there it stays the source of truth: it is re-read on every restart and the config entry it created is updated to match, so an edit to the YAML takes effect. The flip side is that changes made to an imported entry through the UI are overwritten at the next restart - remove the YAML block first if you want to configure it from the UI.
+
+Only `state_template`, `active_child_template` and the `data`/`target`/`action` of a command accept a template. `browse_media_entity` and the values under `attributes` are read as entity ids (`media_player.child`, `media_player.child|volume_level`, or several children joined by `-`); a Jinja2 block there is rejected at startup, or ignored with a warning in the log for an entry imported by an earlier version.
+
 ## Example
 
 The parent media player is a [Music Assistant](https://github.com/music-assistant/hass-music-assistant) media player.  

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Existing YAML-based setups (`media_player: - platform: custom_universal_media_pl
 
 For as long as the YAML block is there it stays the source of truth: it is re-read on every restart and the config entry it created is updated to match, so an edit to the YAML takes effect. The flip side is that changes made to an imported entry through the UI are overwritten at the next restart - remove the YAML block first if you want to configure it from the UI.
 
-Only `state_template`, `active_child_template` and the `data`/`target`/`action` of a command accept a template. `browse_media_entity` and the values under `attributes` are read as entity ids (`media_player.child`, `media_player.child|volume_level`, or several children joined by `-`); a Jinja2 block there is rejected at startup, or ignored with a warning in the log for an entry imported by an earlier version.
+Only `state_template`, `active_child_template` and the `data`/`target`/`action` of a command accept a template - same as the upstream [universal media player](https://www.home-assistant.io/integrations/universal/) this integration forks. `browse_media_entity` and the values under `attributes` are read as entity ids (`media_player.child`, `media_player.child|volume_level`, or several children joined by `-`); a Jinja2 block there is rejected at startup, or ignored with a warning in the log for an entry imported by an earlier version. `browse_media_entity` is checked more strictly here than upstream, so that the YAML asks for exactly what the UI's entity picker already enforces.
 
 ## Example
 

--- a/custom_components/custom_universal_media_player/__init__.py
+++ b/custom_components/custom_universal_media_player/__init__.py
@@ -2,17 +2,52 @@
 
 from __future__ import annotations
 
+import re
 from typing import TYPE_CHECKING
 
-from homeassistant.const import Platform
+from homeassistant.const import CONF_STATE_TEMPLATE, Platform
 
-from .const import ATTR_ENTITY_PICTURE_LOCAL  # pyright: ignore[reportUnusedImport] # noqa: F401
+from .const import (
+    ATTR_ENTITY_PICTURE_LOCAL,  # pyright: ignore[reportUnusedImport] # noqa: F401
+    CONF_ACTIVE_CHILD_TEMPLATE,
+)
 
 if TYPE_CHECKING:
     from homeassistant.config_entries import ConfigEntry
     from homeassistant.core import HomeAssistant
 
 PLATFORMS: list[Platform] = [Platform.MEDIA_PLAYER]
+
+# repr() of a Template, e.g. "Template<template=({{ 1 }}) renders=0>". Versions
+# 1.6 and 1.7 stored that instead of the template's own source, so the entry
+# they wrote holds a string that renders to another repr() rather than a state.
+_TEMPLATE_REPR = re.compile(r"^Template<template=\((?P<source>.*)\) renders=\d+>$", re.DOTALL)
+
+
+async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Migrate a config entry to the current schema.
+
+    Args:
+        hass: The Home Assistant instance.
+        entry: The config entry to migrate.
+
+    Returns:
+        True if the entry could be migrated.
+
+    """
+    if entry.version > 1:
+        # Downgrade: an entry written by a newer version is not readable here.
+        return False
+
+    if entry.minor_version < 2:
+        data = dict(entry.data)
+        for key in (CONF_ACTIVE_CHILD_TEMPLATE, CONF_STATE_TEMPLATE):
+            value = data.get(key)
+            if isinstance(value, str) and (match := _TEMPLATE_REPR.match(value)):
+                data[key] = match.group("source")
+        hass.config_entries.async_update_entry(entry, data=data, minor_version=2)
+
+    return True
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:

--- a/custom_components/custom_universal_media_player/config_flow.py
+++ b/custom_components/custom_universal_media_player/config_flow.py
@@ -187,22 +187,47 @@ def _category_section(category: str) -> str:
     return f"category_{category}"
 
 
-def _extract_entity_id(command: dict[str, Any]) -> str | None:
-    """Extract a single target entity_id from a command, if there is exactly one.
+def _static_target(command: dict[str, Any]) -> dict[str, Any]:
+    """Return a command's target when it is a plain mapping.
+
+    cv.SERVICE_SCHEMA compiles every "{{ ... }}" into a Template, and it
+    accepts one for the whole target as well as for a single entity_id. What
+    such a value resolves to is only known when the command is called, so
+    there is nothing to check it against here - and a Template raises on the
+    dict and string operations these checks rely on.
 
     Args:
         command: The command dict (action/target/data).
 
     Returns:
-        The single target entity_id, or None if there is none or more than one.
+        The target mapping, or an empty one when the target is templated or
+        absent.
 
     """
-    entity_id = command.get("target", {}).get("entity_id")
+    target = command.get("target")
+    return target if isinstance(target, dict) else {}
+
+
+def _extract_entity_id(command: dict[str, Any]) -> str | None:
+    """Extract a single target entity_id from a command, if there is exactly one.
+
+    A templated entity_id has no single value until the command runs, so it
+    counts as "no static entity_id" rather than as one.
+
+    Args:
+        command: The command dict (action/target/data).
+
+    Returns:
+        The single target entity_id, or None if there is none, more than one,
+        or it is templated.
+
+    """
+    entity_id = _static_target(command).get("entity_id")
 
     if isinstance(entity_id, list):
-        return entity_id[0] if len(entity_id) == 1 else None
+        entity_id = entity_id[0] if len(entity_id) == 1 else None
 
-    return entity_id or None
+    return entity_id if isinstance(entity_id, str) and entity_id else None
 
 
 def _format_problems(problems: list[str]) -> str:
@@ -269,8 +294,12 @@ def _is_simple_command(command: dict[str, Any] | None) -> bool:
     if set(command) - {"action", "target"}:
         return False
 
-    target = command.get("target", {})
-    if set(target) - {"entity_id"}:
+    # A templated action or target is only resolved at call time, so it can
+    # never be reduced to the entity + action pair the guided picker shows.
+    if not isinstance(command.get("action"), str):
+        return False
+
+    if set(_static_target(command)) - {"entity_id"}:
         return False
 
     return _extract_entity_id(command) is not None
@@ -982,10 +1011,13 @@ class CustomUniversalMediaPlayerConfigFlow(ConfigFlow, domain=DOMAIN):
         unknown: set[str] = set()
 
         for command in commands.values():
-            entity_id = command.get("target", {}).get("entity_id")
+            entity_id = _static_target(command).get("entity_id")
             entity_ids = entity_id if isinstance(entity_id, list) else [entity_id] if entity_id else []
 
             for candidate in entity_ids:
+                if isinstance(candidate, Template):
+                    # Which entity it points at is only known at call time.
+                    continue
                 if not candidate or self.hass.states.get(candidate) is None:
                     unknown.add(candidate or "(empty)")
 
@@ -1006,7 +1038,8 @@ class CustomUniversalMediaPlayerConfigFlow(ConfigFlow, domain=DOMAIN):
 
         for command in commands.values():
             action = command.get("action")
-            if not action or "." not in action:
+            if not isinstance(action, str) or "." not in action:
+                # A templated action names its service only at call time.
                 continue
 
             domain, _, service = action.partition(".")

--- a/custom_components/custom_universal_media_player/config_flow.py
+++ b/custom_components/custom_universal_media_player/config_flow.py
@@ -187,6 +187,52 @@ def _category_section(category: str) -> str:
     return f"category_{category}"
 
 
+class _BlockStringDumper(yaml.SafeDumper):
+    """A SafeDumper that writes a multi-line string as a "|" block scalar.
+
+    Left to itself, PyYAML renders a string holding newlines as a
+    double-quoted scalar, with escaped newlines and line continuations. A
+    templated command survives the round-trip that way, but comes back
+    unreadable - and these screens exist to be edited by hand.
+    """
+
+
+def _represent_str(dumper: yaml.SafeDumper, data: str) -> yaml.ScalarNode:
+    """Represent a string, using a block scalar when it spans several lines.
+
+    Args:
+        dumper: The dumper doing the serialization.
+        data: The string to represent.
+
+    Returns:
+        The scalar node for that string.
+
+    """
+    return dumper.represent_scalar("tag:yaml.org,2002:str", data, style="|" if "\n" in data else None)
+
+
+_BlockStringDumper.add_representer(str, _represent_str)
+
+
+def _to_yaml(value: dict[str, Any]) -> str:
+    """Serialize a command or attribute mapping for the raw YAML screens.
+
+    The json round-trip drops anything that is not plain JSON data (an
+    OrderedDict, a tuple) so the dump stays free of Python-specific tags.
+
+    Args:
+        value: The mapping to serialize.
+
+    Returns:
+        The YAML text, or an empty string when there is nothing to show.
+
+    """
+    if not value:
+        return ""
+
+    return yaml.dump(json.loads(json.dumps(value)), Dumper=_BlockStringDumper, sort_keys=False, allow_unicode=True)
+
+
 def _static_target(command: dict[str, Any]) -> dict[str, Any]:
     """Return a command's target when it is a plain mapping.
 
@@ -1069,9 +1115,7 @@ class CustomUniversalMediaPlayerConfigFlow(ConfigFlow, domain=DOMAIN):
             preview_yaml = user_input.get(CONF_COMMANDS, "")
         else:
             existing_commands: dict[str, Any] = self._data.get(CONF_COMMANDS, {})
-            preview_yaml = (
-                yaml.safe_dump(json.loads(json.dumps(existing_commands)), sort_keys=False) if existing_commands else ""
-            )
+            preview_yaml = _to_yaml(existing_commands)
 
         schema = vol.Schema({vol.Optional(CONF_COMMANDS): TextSelector(TextSelectorConfig(multiline=True))})
         return schema, preview_yaml
@@ -1122,9 +1166,7 @@ class CustomUniversalMediaPlayerConfigFlow(ConfigFlow, domain=DOMAIN):
             preview_yaml = user_input.get(CONF_ATTRS, "") if user_input else ""
         else:
             existing_attrs: dict[str, Any] = self._data.get(CONF_ATTRS, {})
-            preview_yaml = (
-                yaml.safe_dump(json.loads(json.dumps(existing_attrs)), sort_keys=False) if existing_attrs else ""
-            )
+            preview_yaml = _to_yaml(existing_attrs)
 
         description_placeholders = {"problems": _format_problems(problems)}
 

--- a/custom_components/custom_universal_media_player/config_flow.py
+++ b/custom_components/custom_universal_media_player/config_flow.py
@@ -280,6 +280,7 @@ class CustomUniversalMediaPlayerConfigFlow(ConfigFlow, domain=DOMAIN):
     """Handle a config flow for the custom universal media player."""
 
     VERSION = 1
+    MINOR_VERSION = 2
 
     def __init__(self) -> None:
         """Initialize the config flow state."""
@@ -1198,8 +1199,6 @@ class CustomUniversalMediaPlayerConfigFlow(ConfigFlow, domain=DOMAIN):
 
         """
         unique_id = import_data.get(CONF_UNIQUE_ID) or slugify(import_data[CONF_NAME])
-        await self.async_set_unique_id(unique_id)
-        self._abort_if_unique_id_configured()
 
         active_child_template = import_data.get(CONF_ACTIVE_CHILD_TEMPLATE)
         state_template = import_data.get(CONF_STATE_TEMPLATE)
@@ -1227,5 +1226,14 @@ class CustomUniversalMediaPlayerConfigFlow(ConfigFlow, domain=DOMAIN):
             translation_key="deprecated_yaml",
             translation_placeholders={"integration_title": "Custom universal media player"},
         )
+
+        await self.async_set_unique_id(unique_id)
+
+        # The YAML stays the source of truth for as long as it is there: pass
+        # the freshly read configuration as updates so an edit to the YAML is
+        # picked up on the next restart, and so an entry written by a version
+        # that mangled it is rewritten rather than kept forever. Without this
+        # the very first import wins and nothing can ever correct it.
+        self._abort_if_unique_id_configured(updates=data)
 
         return self.async_create_entry(title=data[CONF_NAME], data=data)

--- a/custom_components/custom_universal_media_player/config_flow.py
+++ b/custom_components/custom_universal_media_player/config_flow.py
@@ -1152,7 +1152,11 @@ class CustomUniversalMediaPlayerConfigFlow(ConfigFlow, domain=DOMAIN):
                     else:
                         unknown_attrs = self._find_unknown_attribute_names(parsed_attrs)
                         if unknown_attrs:
-                            _LOGGER.warning(
+                            # Informational, not a problem: a media_player only
+                            # exposes its media_* and entity_picture attributes
+                            # while it is playing, so an override naming one
+                            # reads as missing whenever the child is idle.
+                            _LOGGER.info(
                                 "Attributes not currently present on their referenced entity "
                                 "(may be normal depending on state): %s",
                                 ", ".join(sorted(unknown_attrs)),

--- a/custom_components/custom_universal_media_player/config_flow.py
+++ b/custom_components/custom_universal_media_player/config_flow.py
@@ -634,21 +634,36 @@ class CustomUniversalMediaPlayerConfigFlow(ConfigFlow, domain=DOMAIN):
         return isinstance(result, str)
 
     def _active_child_template_result_is_valid(self, raw_template: str) -> bool:
-        """Check that active_child_template renders to an existing media_player entity_id.
+        """Check that active_child_template renders to a child entity_id, or to None.
+
+        Unlike state_template, None is a meaningful result here: the field's
+        own description - and the upstream universal media player it comes
+        from - document it as "the entity_id of the child selected as active,
+        or None to use the default behavior". Rendering nothing at all says
+        the same thing, since the entity only tests the result for
+        truthiness. Anything else that is not a string (a bare boolean such
+        as "{{ is_state(...) }}", a number) is still rejected.
 
         Args:
             raw_template: The template source to render and check.
 
         Returns:
-            True if the template renders to a string that is empty, or the
-            entity_id of an existing media_player entity, False otherwise
+            True if the template renders to None, to an empty string, or to
+            the entity_id of an existing media_player entity, False otherwise
             (including if the template fails to render).
 
         """
-        if not self._template_result_is_valid(raw_template):
+        try:
+            result = cv.template(raw_template).async_render(parse_result=True)
+        except TemplateError:
             return False
 
-        result = cv.template(raw_template).async_render(parse_result=True)
+        if result is None:
+            return True
+
+        if not isinstance(result, str):
+            return False
+
         if not result:
             return True
 

--- a/custom_components/custom_universal_media_player/media_player.py
+++ b/custom_components/custom_universal_media_player/media_player.py
@@ -294,10 +294,11 @@ class CustomUniversalMediaPlayer(MediaPlayerEntity):  # pylint: disable=too-many
         self._attr_unique_id = config.get(CONF_UNIQUE_ID)
         self._browse_media_entity = config.get(CONF_BROWSE_MEDIA_ENTITY)
         if self._browse_media_entity and not valid_entity_id(self._browse_media_entity):
-            # A stale config entry can still hold anything here: the YAML schema
-            # only started rejecting a non-entity_id value in v1.9. Advertising
-            # BROWSE_MEDIA for it would make async_browse_media() raise instead
-            # of falling back to the active child.
+            # The schema and the UI's entity picker both ask for an entity_id,
+            # but a config entry imported before they did can still hold
+            # anything. Advertising BROWSE_MEDIA for it would make
+            # async_browse_media() raise instead of falling back to the
+            # active child.
             _LOGGER.warning(
                 "%s: ignoring browse_media_entity, %r is not an entity_id",
                 self._attr_name,

--- a/custom_components/custom_universal_media_player/media_player.py
+++ b/custom_components/custom_universal_media_player/media_player.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from copy import copy
+import logging
 from typing import TYPE_CHECKING, Any, override
 from urllib.parse import urlparse
 
@@ -87,7 +88,7 @@ from homeassistant.const import (
     STATE_UNAVAILABLE,
     STATE_UNKNOWN,
 )
-from homeassistant.core import Event, EventStateChangedData, HomeAssistant, callback
+from homeassistant.core import Event, EventStateChangedData, HomeAssistant, callback, valid_entity_id
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.event import (
     TrackTemplate,
@@ -159,6 +160,8 @@ STATES_ORDER = [
 STATES_ORDER_LOOKUP = {state: idx for idx, state in enumerate(STATES_ORDER)}
 STATES_ORDER_IDLE = STATES_ORDER_LOOKUP[MediaPlayerState.IDLE]
 
+_LOGGER = logging.getLogger(__name__)
+
 ATTRS_SCHEMA: Any = cv.schema_with_slug_keys(cv.string)  # pyright: ignore[reportUnknownVariableType, reportUnknownMemberType]  # pylint: disable=invalid-name
 CMD_SCHEMA: Any = cv.schema_with_slug_keys(cv.SERVICE_SCHEMA)  # pyright: ignore[reportUnknownVariableType, reportUnknownMemberType] # pylint: disable=invalid-name
 
@@ -168,7 +171,7 @@ PLATFORM_SCHEMA = MEDIA_PLAYER_PLATFORM_SCHEMA.extend(  # pyright: ignore[report
         vol.Optional(CONF_CHILDREN, default=[]): cv.entity_ids,  # pyright: ignore[reportUnknownMemberType]
         vol.Optional(CONF_COMMANDS, default={}): CMD_SCHEMA,
         vol.Optional(CONF_ATTRS, default={}): vol.Or(cv.ensure_list(ATTRS_SCHEMA), ATTRS_SCHEMA),
-        vol.Optional(CONF_BROWSE_MEDIA_ENTITY): cv.string,
+        vol.Optional(CONF_BROWSE_MEDIA_ENTITY): cv.entity_id,
         vol.Optional(CONF_UNIQUE_ID): cv.string,
         vol.Optional(CONF_DEVICE_CLASS): DEVICE_CLASSES_SCHEMA,
         vol.Optional(CONF_ACTIVE_CHILD_TEMPLATE): cv.template,
@@ -176,6 +179,27 @@ PLATFORM_SCHEMA = MEDIA_PLAYER_PLATFORM_SCHEMA.extend(  # pyright: ignore[report
     },
     extra=vol.REMOVE_EXTRA,
 )
+
+
+def _attr_entity_ids_are_valid(entity_part: str | None) -> bool:
+    """Check that an attribute override points at entity_ids and nothing else.
+
+    The entity half of an override is a single entity_id, or several of them
+    joined by "-" (see _entity_lkp). It is not a template: a Jinja2 block put
+    there is read verbatim as an entity_id, which silently resolves to nothing.
+
+    Args:
+        entity_part: The part of the override left of the "|" separator.
+
+    Returns:
+        True if every entity_id in the override is a valid one.
+
+    """
+    if not entity_part:
+        return False
+
+    entity_ids = [entity_id.strip() for entity_id in entity_part.split("-")]
+    return all(entity_ids) and all(valid_entity_id(entity_id) for entity_id in entity_ids)
 
 
 async def async_setup_platform(
@@ -252,6 +276,16 @@ class CustomUniversalMediaPlayer(MediaPlayerEntity):  # pylint: disable=too-many
             attr: list[str | None] = list(map(str.strip, val.split("|", 1)))
             if len(attr) == 1:
                 attr.append(None)
+            if not _attr_entity_ids_are_valid(attr[0]):
+                _LOGGER.warning(
+                    "%s: ignoring the '%s' attribute override, %r is not an entity_id. "
+                    "An attribute override points at a child entity ('media_player.child' or "
+                    "'media_player.child|volume_level'); it is not a template",
+                    self._attr_name,
+                    key,
+                    val,
+                )
+                continue
             self._attrs[key] = attr
         self._child_state = None
         self._state_template_result = None
@@ -259,6 +293,17 @@ class CustomUniversalMediaPlayer(MediaPlayerEntity):  # pylint: disable=too-many
         self._attr_device_class = config.get(CONF_DEVICE_CLASS)
         self._attr_unique_id = config.get(CONF_UNIQUE_ID)
         self._browse_media_entity = config.get(CONF_BROWSE_MEDIA_ENTITY)
+        if self._browse_media_entity and not valid_entity_id(self._browse_media_entity):
+            # A stale config entry can still hold anything here: the YAML schema
+            # only started rejecting a non-entity_id value in v1.9. Advertising
+            # BROWSE_MEDIA for it would make async_browse_media() raise instead
+            # of falling back to the active child.
+            _LOGGER.warning(
+                "%s: ignoring browse_media_entity, %r is not an entity_id",
+                self._attr_name,
+                self._browse_media_entity,
+            )
+            self._browse_media_entity = None
 
     @override
     async def async_added_to_hass(self) -> None:
@@ -323,7 +368,9 @@ class CustomUniversalMediaPlayer(MediaPlayerEntity):  # pylint: disable=too-many
 
         depend: Any = copy(self._children)
         for entity in self._attrs.values():
-            depend.append(entity[0])
+            # An override may chain several entities ("a-b"), the way _entity_lkp
+            # reads them back; each one has to be tracked on its own.
+            depend.extend(entity[0].split("-"))
 
         self.async_on_remove(async_track_state_change_event(self.hass, list(set(depend)), _async_on_dependency_update))
 

--- a/custom_components/custom_universal_media_player/strings.json
+++ b/custom_components/custom_universal_media_player/strings.json
@@ -202,7 +202,7 @@
       "incomplete_command": "Incorrect configuration to fix : pick both an entity and an action, or leave both blank",
       "invalid_commands": "Invalid configuration, see details below.",
       "invalid_template_result": "This template must render to a plain state value, not a boolean, number or other type.",
-      "invalid_active_child_template_result": "This template must render to the entity_id of an existing media player, or be left empty."
+      "invalid_active_child_template_result": "This template must render to the entity_id of an existing media player, or to None (or nothing at all) to use the default behavior."
     },
     "abort": {
       "already_configured": "Device is already configured",

--- a/custom_components/custom_universal_media_player/translations/en.json
+++ b/custom_components/custom_universal_media_player/translations/en.json
@@ -202,7 +202,7 @@
       "incomplete_command": "Incorrect configuration to fix : pick both an entity and an action, or leave both blank",
       "invalid_commands": "Invalid configuration, see details below.",
       "invalid_template_result": "This template must render to a plain state value, not a boolean, number or other type.",
-      "invalid_active_child_template_result": "This template must render to the entity_id of an existing media player, or be left empty."
+      "invalid_active_child_template_result": "This template must render to the entity_id of an existing media player, or to None (or nothing at all) to use the default behavior."
     },
     "abort": {
       "already_configured": "Device is already configured",

--- a/scripts/check_config_flow
+++ b/scripts/check_config_flow
@@ -409,6 +409,65 @@ def check_attributes_validation() -> None:
     asyncio.run(_check_missing_attribute_not_in_ui())
 
 
+def check_templated_commands_do_not_crash() -> None:
+    """Regression test: a templated action or target must not crash the review.
+
+    cv.SERVICE_SCHEMA compiles every "{{ ... }}" into a Template, including a
+    target's entity_id and the whole target. The review screen used to hand
+    those straight to hass.states.get() ("'Template' object has no attribute
+    'lower'"), to `"." not in action` ("not iterable") and to set() ("not
+    iterable"). What they resolve to is only known at call time, so they must
+    be skipped, not reported and not crashed on.
+    """
+    import custom_universal_media_player.config_flow as cf  # noqa: PLC0415
+
+    from homeassistant.core import HomeAssistant  # noqa: PLC0415
+    import homeassistant.helpers.config_validation as cv  # noqa: PLC0415
+
+    templated = "{% if is_state('input_select.x', 'a') %}media_player.a{% else %}media_player.b{% endif %}"
+
+    async def _check() -> None:
+        hass = HomeAssistant("/tmp")  # noqa: S108
+        hass.services.async_register("media_player", "media_play", lambda _call: None)
+        flow = cf.CustomUniversalMediaPlayerConfigFlow()
+        flow.hass = hass
+
+        commands = cv.schema_with_slug_keys(cv.SERVICE_SCHEMA)(
+            {
+                "media_play": {"action": "media_player.media_play", "target": {"entity_id": templated}},
+                "turn_off": {"action": templated.replace("media_player.", "script.")},
+                "media_stop": {"action": "media_player.media_play", "target": "{{ {'entity_id': 'x'} }}"},
+            },
+        )
+
+        for label, call in (
+            ("_find_unknown_entities", lambda: flow._find_unknown_entities(commands)),  # noqa: SLF001
+            ("_find_unknown_actions", lambda: flow._find_unknown_actions(commands)),  # noqa: SLF001
+            ("_extract_entity_id", lambda: cf._extract_entity_id(commands["media_play"])),  # noqa: SLF001
+            ("_is_simple_command", lambda: cf._is_simple_command(commands["media_play"])),  # noqa: SLF001
+        ):
+            try:
+                result = call()
+            except (AttributeError, TypeError) as err:
+                report(f"templated command: {label} does not crash", False, f"{type(err).__name__}: {err}")
+                continue
+            report(f"templated command: {label} does not crash", True)
+            if label.startswith("_find_unknown"):
+                report(
+                    f"templated command: {label} reports nothing",
+                    result == set(),
+                    f"expected an empty set, got {result!r}",
+                )
+
+        report(
+            "templated command: a templated target is not a simple command",
+            cf._is_simple_command(commands["media_play"]) is False,  # noqa: SLF001
+            "a templated target cannot be shown in the guided picker",
+        )
+
+    asyncio.run(_check())
+
+
 def check_active_child_template_accepts_none() -> None:
     """Regression test: active_child_template must accept a None result.
 
@@ -470,6 +529,7 @@ def main() -> int:
     check_empty_entity_id_does_not_crash()
     check_command_validation_is_cumulative()
     check_attributes_validation()
+    check_templated_commands_do_not_crash()
     check_active_child_template_accepts_none()
 
     print()

--- a/scripts/check_config_flow
+++ b/scripts/check_config_flow
@@ -409,6 +409,51 @@ def check_attributes_validation() -> None:
     asyncio.run(_check_missing_attribute_not_in_ui())
 
 
+def check_active_child_template_accepts_none() -> None:
+    """Regression test: active_child_template must accept a None result.
+
+    The field's own description says the template returns "the entity_id of
+    the child selected as active, or None to use the default behavior", and
+    the entity honors that - a non-string result is stored as None and falls
+    back to picking the most active child. The validator used to reject it,
+    so the UI refused the very value its help text asks for. "null" is not
+    one of them: it is not a Python literal, so it stays the string "null"
+    and resolves to no active child at all.
+    """
+    import custom_universal_media_player.config_flow as cf  # noqa: PLC0415
+
+    from homeassistant.core import HomeAssistant  # noqa: PLC0415
+
+    async def _check() -> None:
+        # This validator renders the template, so it needs the real template
+        # engine and a real state machine - _FakeHass is not enough here.
+        hass = HomeAssistant("/tmp")  # noqa: S108
+        hass.states.async_set("media_player.child", "playing")
+        flow = cf.CustomUniversalMediaPlayerConfigFlow()
+        flow.hass = hass
+
+        cases = {
+            "{{ none }}": True,
+            "None": True,
+            "": True,
+            "{% if false %}media_player.child{% endif %}": True,
+            "media_player.child": True,
+            "null": False,
+            "media_player.unknown": False,
+            "{{ 1 == 1 }}": False,
+            "{{ 42 }}": False,
+        }
+        for raw_template, expected in cases.items():
+            actual = flow._active_child_template_result_is_valid(raw_template)  # noqa: SLF001
+            report(
+                f"active_child_template: {raw_template!r} is {'accepted' if expected else 'rejected'}",
+                actual is expected,
+                f"expected {expected}, got {actual}",
+            )
+
+    asyncio.run(_check())
+
+
 def main() -> int:
     """Run all checks and return a process exit code.
 
@@ -425,6 +470,7 @@ def main() -> int:
     check_empty_entity_id_does_not_crash()
     check_command_validation_is_cumulative()
     check_attributes_validation()
+    check_active_child_template_accepts_none()
 
     print()
     if FAILURES:

--- a/scripts/check_config_flow
+++ b/scripts/check_config_flow
@@ -409,6 +409,41 @@ def check_attributes_validation() -> None:
     asyncio.run(_check_missing_attribute_not_in_ui())
 
 
+def check_yaml_preview_is_readable() -> None:
+    """Regression test: a multi-line value must redisplay as a block scalar.
+
+    PyYAML's default for a string holding newlines is a double-quoted scalar
+    with "\\n" escapes and line continuations. A templated command survived
+    that round-trip, but came back unreadable - and these screens exist to be
+    edited by hand.
+    """
+    import custom_universal_media_player.config_flow as cf  # noqa: PLC0415
+
+    import yaml  # noqa: PLC0415
+
+    commands = {
+        "turn_off": {"action": "{% if is_state('input_select.x', 'a') %}\nscript.a\n{% else %}\nscript.b\n{% endif %}"},
+        "volume_set": {"action": "media_player.volume_set", "data": {"volume_level": "{{ volume_level }}"}},
+    }
+    preview = cf._to_yaml(commands)  # noqa: SLF001
+
+    report(
+        "yaml preview: a multi-line value uses a block scalar",
+        "action: |" in preview and "\\n" not in preview,
+        f"expected a block scalar, got:\n{preview}",
+    )
+    report(
+        "yaml preview: what is redisplayed parses back unchanged",
+        yaml.safe_load(preview) == commands,
+        f"round-trip changed the commands:\n{preview}",
+    )
+    report(
+        "yaml preview: an empty mapping stays an empty textarea",
+        cf._to_yaml({}) == "",  # noqa: SLF001
+        "an empty mapping must not render as '{}'",
+    )
+
+
 def check_templated_commands_do_not_crash() -> None:
     """Regression test: a templated action or target must not crash the review.
 
@@ -529,6 +564,7 @@ def main() -> int:
     check_empty_entity_id_does_not_crash()
     check_command_validation_is_cumulative()
     check_attributes_validation()
+    check_yaml_preview_is_readable()
     check_templated_commands_do_not_crash()
     check_active_child_template_accepts_none()
 


### PR DESCRIPTION
## Fixes

Four independent bugs found while investigating the reported "YAML imported configurations no longer available". See the commits for the details.

- **The YAML import never refreshed its config entry.** The first import won forever: YAML edits never reached the entry, and an entry mangled by 1.6 or 1.7 stayed broken. The YAML is now the source of truth for as long as it is there, and `async_migrate_entry` repairs entries whose YAML is already gone.
- **`active_child_template` rejected `None`**, the value its own help text and upstream's docs prescribe, and pointed at "be left empty" instead — a spelling documented nowhere. (`null` is not a spelling of `None`: it stays a truthy string and resolves to no active child at all.)
- **Saving a templated command crashed the review screen** — a `Template` was handed to code expecting plain strings and mappings. Templates resolve only at call time, so the static checks now skip them.
- **`browse_media_entity` and `attributes` failed silently** when given a template. They are entity ids, not templates; a Jinja2 block resolved to nothing while still advertising `BROWSE_MEDIA`, which made `async_browse_media()` raise instead of falling back to the active child. The YAML schema now asks for an entity id, matching the entity picker the UI already enforces, and a stale value from an older entry is ignored with a warning.

## Note

As long as a YAML block exists it wins on every restart, so changes made through the UI to an imported entry are overwritten. Documented in the README, worth a line in the release notes.